### PR TITLE
Proposed fix for iTunes 11 RemoteApp 3.0 fails to play songs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ libtool
 ltmain.sh
 missing
 stamp-h1
+autotools-stamp
+build-stamp
 
 # ignore debian packaging for convenience
 debian/

--- a/src/DAAP2SQL.g
+++ b/src/DAAP2SQL.g
@@ -133,6 +133,7 @@ expr	returns [ pANTLR3_STRING result, int valid ]
 
 			val = field;
 			while ((*val != '\0') && ((*val == '.')
+				|| (*val == '-')
 				|| ((*val >= 'a') && (*val <= 'z'))
 				|| ((*val >= 'A') && (*val <= 'Z'))
 				|| ((*val >= '0') && (*val <= '9'))))

--- a/src/daap_query.gperf
+++ b/src/daap_query.gperf
@@ -37,3 +37,4 @@ struct dmap_query_field_map;
 "daap.songtracknumber",       "f.track",            1
 "daap.songyear",              "f.year",             1
 "com.apple.itunes.mediakind", "f.media_kind",       1
+"com.apple.itunes.extended-media-kind",  "f.media_kind",         1

--- a/src/dacp_prop.gperf
+++ b/src/dacp_prop.gperf
@@ -20,3 +20,9 @@ struct dacp_prop_map;
 "dacp.shufflestate",           dacp_propget_shufflestate,           dacp_propset_shufflestate
 "dacp.repeatstate",            dacp_propget_repeatstate,            dacp_propset_repeatstate
 "dacp.userrating",             NULL,                                dacp_propset_userrating
+"dacp.fullscreenenabled",      dacp_propget_fullscreenenabled,      NULL
+"dacp.fullscreen",             dacp_propget_fullscreen,             NULL
+"dacp.visualizerenabled",      dacp_propget_visualizerenabled,      NULL
+"dacp.visualizer",             dacp_propget_visualizer,             NULL
+"com.apple.itunes.itms-songid", dacp_propget_itms_songid,           NULL
+"com.apple.itunes.has-chapter-data", dacp_propget_haschapterdata,   NULL

--- a/src/db.c
+++ b/src/db.c
@@ -1168,16 +1168,16 @@ db_build_query_browse(struct query_params *qp, char *field, char **q)
 
   if (idx && qp->filter)
     query = sqlite3_mprintf("SELECT DISTINCT f.%s, f.%s FROM files f WHERE f.data_kind = 0 AND f.disabled = 0 AND f.%s != ''"
-			    " AND %s %s;", field, field, field, qp->filter, idx);
+			    " AND %s ORDER BY f.%s %s;", field, field, field, qp->filter, field, idx);
   else if (idx)
     query = sqlite3_mprintf("SELECT DISTINCT f.%s, f.%s FROM files f WHERE f.data_kind = 0 AND f.disabled = 0 AND f.%s != ''"
-			    " %s;", field, field, field, idx);
+			    " ORDER BY f.%s %s;", field, field, field, field, idx);
   else if (qp->filter)
     query = sqlite3_mprintf("SELECT DISTINCT f.%s, f.%s FROM files f WHERE f.data_kind = 0 AND f.disabled = 0 AND f.%s != ''"
-			    " AND %s;", field, field, field, qp->filter);
+			    " AND %s ORDER BY f.%s;", field, field, field, qp->filter, field);
   else
-    query = sqlite3_mprintf("SELECT DISTINCT f.%s, f.%s FROM files f WHERE f.data_kind = 0 AND f.disabled = 0 AND f.%s != ''",
-			    field, field, field);
+    query = sqlite3_mprintf("SELECT DISTINCT f.%s, f.%s FROM files f WHERE f.data_kind = 0 AND f.disabled = 0 AND f.%s != '' ORDER BY f.%s",
+			    field, field, field, field);
 
   if (!query)
     {

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -99,6 +99,19 @@ dacp_propget_nowplaying(struct evbuffer *evbuf, struct player_status *status, st
 static void
 dacp_propget_playingtime(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi);
 
+static void
+dacp_propget_fullscreenenabled(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi);
+static void
+dacp_propget_fullscreen(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi);
+static void
+dacp_propget_visualizerenabled(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi);
+static void
+dacp_propget_visualizer(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi);
+static void
+dacp_propget_itms_songid(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi);
+static void
+dacp_propget_haschapterdata(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi);
+
 /* Forward - properties setters */
 static void
 dacp_propset_volume(const char *value, struct keyval *query);
@@ -432,6 +445,43 @@ dacp_propget_playingtime(struct evbuffer *evbuf, struct player_status *status, s
 {
   dacp_playingtime(evbuf, status, mfi);
 }
+
+static void
+dacp_propget_fullscreenenabled(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi)
+{
+	// TODO
+}
+
+static void
+dacp_propget_fullscreen(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi)
+{
+	// TODO
+}
+
+static void
+dacp_propget_visualizerenabled(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi)
+{
+	// TODO
+}
+
+static void
+dacp_propget_visualizer(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi)
+{
+	// TODO
+}
+
+static void
+dacp_propget_itms_songid(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi)
+{
+	// TODO
+}
+
+static void
+dacp_propget_haschapterdata(struct evbuffer *evbuf, struct player_status *status, struct media_file_info *mfi)
+{
+	// TODO
+}
+
 
 /* Properties setters */
 static void


### PR DESCRIPTION
Proposed fix for the broken communication between the RemoteApp 3.0 and forked-daapd
